### PR TITLE
import ExampleSchema from the example_resources module in example unit-test

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/tests/routes/test_example_routes.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/tests/routes/test_example_routes.py
@@ -21,7 +21,7 @@ from mock import patch
 
 from {{cookiecutter.project_name}}.app import create_app
 from {{cookiecutter.project_name}}.models.example_model import Example
-from {{cookiecutter.project_name}}.routes.example_routes import ExampleSchema
+from {{cookiecutter.project_name}}.resources.example_resources import ExampleSchema
 
 
 class ExampleMatcher(JSONMatcher):


### PR DESCRIPTION
Just noticed that the example unit-test imports the resource from the route rather than directly
from the resource module