### PR TITLE
Improve database boilerplate:

### DIFF
--- a/{{cookiecutter.repo_name}}/Dockerfile
+++ b/{{cookiecutter.repo_name}}/Dockerfile
@@ -14,4 +14,4 @@ RUN pip install --extra-index-url $GEM_FURY_URL .
 # Copy source and reinstall
 COPY $NAME /src/$NAME/
 RUN rm -rf /src/$NAME/tests
-RUN pip install -U .
+RUN pip install -U -e .

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -18,7 +18,9 @@ setup(
         "microcosm-flask>=0.4.0",
         "microcosm-logging>=0.5.0",
         "microcosm-postgres>=0.3.0",
+        "ndg-httpsclient>=0.4.0",
         "newrelic>=2.60.0",
+        "uwsgi>=2.0.10",
     ],
     setup_requires=[
         "nose>=1.3.6",

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/app.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/app.py
@@ -11,7 +11,7 @@ from {{cookiecutter.project_name}}.routes import example_routes  # noqa
 from {{cookiecutter.project_name}}.stores import example_store  # noqa
 
 
-def create_app(debug=False, testing=False):
+def create_app(debug=False, testing=False, model_only=False):
     """
     Create the object graph for the application.
 
@@ -29,14 +29,18 @@ def create_app(debug=False, testing=False):
     )
 
     graph.use(
-        "discovery_convention",
-        "example_routes",
-        "health_convention",
         "postgres",
-        "postgres_health_check",
         "sessionmaker",
         "session_factory",
-        "swagger_convention",
     )
+
+    if not model_only:
+        graph.use(
+            "discovery_convention",
+            "example_routes",
+            "health_convention",
+            "postgres_health_check",
+            "swagger_convention",
+        )
 
     return graph.lock()

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/app.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/app.py
@@ -3,7 +3,7 @@ Create the application.
 
 """
 from microcosm.api import create_object_graph
-from microcosm.loaders import load_each, load_from_environ_as_json
+from microcosm.loaders import load_each, load_from_environ, load_from_python_file
 
 from {{cookiecutter.project_name}} import postgres  # noqa
 from {{cookiecutter.project_name}}.config import load_default_config
@@ -18,7 +18,8 @@ def create_app(debug=False, testing=False, model_only=False):
     """
     loader = load_each(
         load_default_config,
-        load_from_environ_as_json,
+        load_from_python_file,
+        load_from_environ,
     )
 
     graph = create_object_graph(

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/app.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/app.py
@@ -30,6 +30,7 @@ def create_app(debug=False, testing=False, model_only=False):
     )
 
     graph.use(
+        "logging",
         "postgres",
         "sessionmaker",
         "session_factory",

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/main.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/main.py
@@ -14,7 +14,7 @@ def createall():
     Create (and possibly drop) database tables.
 
     """
-    graph = create_app(debug=True)
+    graph = create_app(debug=True, model_only=True)
     createall_main(graph)
 
 
@@ -23,7 +23,7 @@ def migrate():
     Invoke Alembic migrations.
 
     """
-    graph = create_app(debug=True)
+    graph = create_app(debug=True, model_only=True)
     migrate_main(graph)
 
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/tests/routes/test_example_routes.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/tests/routes/test_example_routes.py
@@ -58,6 +58,9 @@ class TestExampleRoutes(object):
             name=self.name1,
         )
 
+    def teardown(self):
+        self.graph.postgres.dispose()
+
     def test_search(self):
         with SessionContext(self.graph), transaction():
             self.example1.create()

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/tests/stores/test_example_store.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/tests/stores/test_example_store.py
@@ -33,6 +33,7 @@ class TestExamples(object):
 
     def teardown(self):
         self.context.close()
+        self.graph.postgres.dispose()
 
     def test_create(self):
         """


### PR DESCRIPTION
 - Only initialize the model portion of the graph during CLI database operations
 - Tear down the entire connection pool explicitly on test teardown