### PR TITLE
Update routes to use latest conventions.

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/routes/example_routes.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/routes/example_routes.py
@@ -3,6 +3,7 @@ Create example routes.
 
 """
 from microcosm.api import binding, defaults
+from microcosm_flask.conventions.base import EndpointDefinition
 from microcosm_flask.conventions.crud import configure_crud
 from microcosm_flask.conventions.crud_adapter import CRUDStoreAdapter
 from microcosm_flask.operations import Operation
@@ -16,38 +17,38 @@ from {{cookiecutter.project_name}}.resources.example_resources import ExampleSch
 
 @binding("example_routes")
 @defaults(
-    path_prefix="/v1",
+    version="v1",
 )
 def configure_example_routes(graph):
 
     ns = Namespace(
         subject=Example,
-        path=graph.config.example_routes.path_prefix,
+        version=graph.config.example_routes.version,
     )
     adapter = CRUDStoreAdapter(graph, graph.example_store)
 
     mappings = {
-        Operation.Create: (
-            transactional(adapter.create),
-            NewExampleSchema(),
-            ExampleSchema(),
+        Operation.Create: EndpointDefinition(
+            func=transactional(adapter.create),
+            request_schema=NewExampleSchema(),
+            response_schema=ExampleSchema(),
         ),
-        Operation.Delete: (
-            transactional(adapter.delete),
+        Operation.Delete: EndpointDefinition(
+            func=transactional(adapter.delete),
         ),
-        Operation.Replace: (
-            transactional(adapter.replace),
-            NewExampleSchema(),
-            ExampleSchema(),
+        Operation.Replace: EndpointDefinition(
+            func=transactional(adapter.replace),
+            request_schema=NewExampleSchema(),
+            response_schema=ExampleSchema(),
         ),
-        Operation.Retrieve: (
-            adapter.retrieve,
-            ExampleSchema(),
+        Operation.Retrieve: EndpointDefinition(
+            func=adapter.retrieve,
+            response_schema=ExampleSchema(),
         ),
-        Operation.Search: (
-            adapter.search,
-            PageSchema(),
-            ExampleSchema(),
+        Operation.Search: EndpointDefinition(
+            func=adapter.search,
+            request_schema=PageSchema(),
+            response_schema=ExampleSchema(),
         ),
     }
 


### PR DESCRIPTION
- Use the `EndpointDefinition` for better clarity
- Use the `version` attribute of the `Namespace` preferentially