### PR TITLE
Ignoring docker build stages

### DIFF
--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -92,3 +92,9 @@ docs/_build/
 
 # PyBuilder
 target/
+Dockerfile
+{{ cookiecutter.project_name}}.build/docker-base/*
+!{{ cookiecutter.project_name}}.build/docker-base/build.sh
+!{{ cookiecutter.project_name}}.build/docker-base/Dockerfile.template
+!{{ cookiecutter.project_name}}.build/docker-base/Dockerfile.deps
+


### PR DESCRIPTION
Basically, after we made the changes to the docker build in order to
provide better caching, we want to make sure we have the ignore rules on
all projects