### PR TITLE
Update cookiecutter.json to fix 'posgres' typo

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,5 +7,5 @@
     "project_version": "0.1.0",
     "short_description": "Short Project Description",
     "service_port": 5000,
-    "database": ["posgres", "elasticsearch", "memcached", "neo4j"]
+    "database": ["postgres", "elasticsearch", "memcached", "neo4j"]
 }


### PR DESCRIPTION
We had a typo 'posgres' which ends up in .globality/build.json which isnt good. Existing services do indeed have the correct spelling in that file.