### PR TITLE
Fixed issue with url in README resulting in error page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,96 @@
+##
+# .gitignore
+#
+# Based on:
+#
+# https://github.com/github/gitignore/blob/master/Global/OSX.gitignore
+# https://github.com/github/gitignore/blob/master/Python.gitignore
+##
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+.mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,45 +1,5 @@
-##
-# .gitignore
-#
-# Based on:
-#
-# https://github.com/github/gitignore/blob/master/Global/OSX.gitignore
-# https://github.com/github/gitignore/blob/master/Python.gitignore
-##
-
-.DS_Store
-.AppleDouble
-.LSOverride
-
-# Icon must end with two \r
-Icon
-
-
-# Thumbnails
-._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
-
-
-# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
-
-# C extensions
-*.so
 
 # Distribution / packaging
 .Python
@@ -79,18 +39,5 @@ nosetests.xml
 coverage.xml
 *,cover
 cover
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
 
 .mypy_cache/

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -40,7 +40,7 @@ The service publishes several endpoints by default.
  -  The service publishes a [crawlable](https://en.wikipedia.org/wiki/HATEOAS) endpoint for discovery
     of its operations:
 
-        GET /api/
+        GET /api
 
  -  The service publishes [Swagger](http://swagger.io/) definitions for its operations (by API version)
     using [HAL JSON](http://stateless.co/hal_specification.html):


### PR DESCRIPTION
![Screenshot 2019-10-29 at 17 10 15](https://user-images.githubusercontent.com/57096951/67791304-1ad52180-fa6f-11e9-948f-6544526dd041.png)

Cause:
Trailing slash

Added .gitignore file to keep Datree happy