### PR TITLE
A few fixes to get the cookiecutter template working again out of the box

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -19,7 +19,7 @@ setup(
         "microcosm>=2.12.0",
         "microcosm-flask[metrics,spooky]>=1.20.0",
         "microcosm-logging>=1.3.0",
-        "microcosm-postgres>=1.9.1",
+        "microcosm-postgres>=1.19.0",
         "microcosm-secretsmanager>=1.1.0",
         "pyOpenSSL>=18.0.0",
     ],

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/stores/example_store.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/stores/example_store.py
@@ -12,7 +12,7 @@ from {{ cookiecutter.project_name }}.models.example_model import Example
 class ExampleStore(Store):
 
     def __init__(self, graph):
-        super().__init__(self, Example)
+        super().__init__(graph, Example)
 
     def retrieve_by_name(self, name):
         return self._retrieve(Example.name == name)


### PR DESCRIPTION
- fix store constructor bug using `self` instead of `graph` as first argument
- bump microcosm-postgres dep version to try and fix the locked python-dateutil version issue