### PR TITLE
Update isort whitespace setting

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -9,7 +9,7 @@ exclude = */migrations/*,.eggs/*
 
 [isort]
 combine_as_imports=True
-enforce_white_space=True
+ignore_whitespace=False
 force_grid_wrap=4
 include_trailing_comma=True
 known_first_party={{ cookiecutter.project_name }}


### PR DESCRIPTION
In version 4.2.8 of isort, the enforce-whitespace setting was replaced with the ignore-whitespace setting. See https://pycqa.github.io/isort/CHANGELOG/#428-may-31-2017

This commit updates the settings.cfg to stay up-to-date with that change.