### PR TITLE
Make database_migration_head healthcheck optional

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/postgres.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/postgres.py
@@ -27,4 +27,4 @@ def configure_postgres_health_check(graph):
 
     """
     graph.health_convention.checks["database"] = check_alembic
-    graph.health_convention.checks["database_migration_head"] = get_current_head_version
+    graph.health_convention.optional_checks["database_migration_head"] = get_current_head_version


### PR DESCRIPTION
- make database_migration_head healthcheck optional

Why?

This is a "human facing" check that slows down over time as more and more migrations are added.